### PR TITLE
fix: Succeed upon invalid syntax

### DIFF
--- a/src/ruff_reader.rs
+++ b/src/ruff_reader.rs
@@ -21,8 +21,11 @@ pub fn read_codes() -> HashSet<Linter> {
         .expect("failed to execute process");
     let out = String::from_utf8_lossy(&output.stdout);
 
-    let items: Vec<RuffSparseJson> =
-        serde_json::from_str(&out).expect("Could not read json from ruff.");
+    let items: Vec<RuffSparseJson> = serde_json::from_str::<Vec<RuffSparseJson>>(&out)
+        .expect("Could not read json from ruff.")
+        .into_iter()
+        .filter(|item| item.code != "invalid-syntax")
+        .collect();
 
     let mut unique_groups = HashSet::new();
 


### PR DESCRIPTION
> like ruff check does.
> 
> Ruff outputs `invalid-syntax` like an error-code in json, but does not do in the rest of its code.
> It e.g. is not possible to --ignore it in CLI.

Thanks to @s-2 for the report!